### PR TITLE
Use `utils.cache.list()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,22 @@
 const fs = require('fs')
 const path = require('path')
 const { promisify } = require('util')
-const readdirP = promisify(fs.readdir)
-const statP = promisify(fs.stat)
 const writeFile = promisify(fs.writeFile)
 
 module.exports = function netlifyPlugin(config) {
   return {
     name: 'netlify-plugin-debug-cache',
-    onEnd: async ({ constants, pluginConfig }) => {
-      const { BUILD_DIR, CACHE_DIR } = constants
+    onEnd: async ({ constants, pluginConfig, utils }) => {
+      const { BUILD_DIR } = constants
       const cacheManifestFileName = pluginConfig.outputFile || 'cache-output.json'
       const cacheManifestPath = path.join(BUILD_DIR, cacheManifestFileName)
       console.log('Saving cache file manifest for debugging...')
       let files = []
       try {
-        files = await getCacheInfo({
-          cacheDirectory: CACHE_DIR,
-          outputPath: cacheManifestPath,
-        })
+        files = await utils.cache.list()
+        if (cacheManifestPath) {
+          await writeFile(cacheManifestPath, JSON.stringify(files, null, 2))
+        }
       } catch (err) {
         console.log(`netlify-plugin-debug-cache error`)
         console.log(err)
@@ -31,31 +29,3 @@ module.exports = function netlifyPlugin(config) {
   }
 }
 
-async function readDir(dir, allFiles = []) {
-  const files = (await readdirP(dir)).map(f => path.join(dir, f))
-  allFiles.push(...files)
-  await Promise.all(
-    files.map(
-      async f => (await statP(f)).isDirectory() && readDir(f, allFiles)
-    )
-  )
-  return allFiles
-}
-
-async function getCacheInfo(opts = {}) {
-  if (!opts.cacheDirectory) {
-    throw new Error('Must specify cacheDirectory to read')
-  }
-  let files
-  try {
-    // Recursively read all files in the cache directory
-    files = await readDir(opts.cacheDirectory)
-    // Write cache map into a file to download after build succeeds
-    if (opts.outputPath) {
-      await writeFile(opts.outputPath, JSON.stringify(files, null, 2))
-    }
-  } catch (e) {
-    console.log('err', e)
-  }
-  return files
-}


### PR DESCRIPTION
This PR simplifies the code by using the [`utils.cache.list()` built-in function](https://github.com/netlify/build/blob/master/packages/cache-utils/README.md#list).
This does not change the behavior otherwise.