### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,14 @@ Debug & verify the contents of your Netlify build cache
 
 ## Install
 
-```bash
-npm install netlify-plugin-debug-cache
+To install, add the following lines to your `netlify.toml` file, after any other plugins you may have added:
+
+```toml
+[[plugins]]
+package = "netlify-plugin-debug-cache"
 ```
 
-## Usage
-
-In your Netlify config file, add the plugin
-
-```yml
-# Build plugins
-plugins:
-  # Make sure to add as the last plugin
-  - package: netlify-plugin-debug-cache
-```
+Note: The `[[plugins]]` line is required for each plugin, even if you have other plugins in your `netlify.toml` file already.
 
 After the build is complete, download the built assets and inspect the cache manifest file.
 


### PR DESCRIPTION
For greater simplicity and consistency with Netlify users’ existing configuration files, we’re deprecating experimental support for Netlify config files in YAML or JSON (https://github.com/netlify/build/issues/975).

To get new plugin users started on the right foot, I’m proposing updates for all plugin READMEs to use `netlify.toml` format in the installation instructions.

I've also made the following updates to reflect the current plugins API:
- Removed the `npm install` step. This is no longer necessary.