### PR TITLE
Fix crash when `PUBLISH_DIR` does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ const path = require('path')
 const { promisify } = require('util')
 const writeFile = promisify(fs.writeFile)
 
+const makeDir = require('make-dir')
+
 module.exports = {
     onEnd: async ({ constants, inputs, utils }) => {
       const { PUBLISH_DIR } = constants
@@ -10,6 +12,7 @@ module.exports = {
       const cacheManifestPath = path.join(PUBLISH_DIR, cacheManifestFileName)
       console.log('Saving cache file manifest for debugging...')
       const files = await utils.cache.list()
+      await makeDir(PUBLISH_DIR)
       await writeFile(cacheManifestPath, JSON.stringify(files, null, 2))
       console.log(`Cache file count: ${files.length}`)
       console.log(`Cache manifest saved to ${cacheManifestPath}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,21 @@
 {
   "name": "netlify-plugin-debug-cache",
   "version": "1.0.2",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "requires": {
+        "semver": "^6.0.0"
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "netlify",
     "netlify-plugin",
     "cache"
-  ]
+  ],
+  "dependencies": {
+    "make-dir": "^3.1.0"
+  }
 }


### PR DESCRIPTION
Fixes #5.

This plugin was crashing when `PUBLISH_DIR` did not exist.