### PR TITLE
change to run the plugin before the deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const writeFile = promisify(fs.writeFile)
 const makeDir = require('make-dir')
 
 module.exports = {
-    onEnd: async ({ constants, inputs, utils }) => {
+    onPostBuild: async ({ constants, inputs, utils }) => {
       const { PUBLISH_DIR } = constants
       const cacheManifestFileName = inputs.outputFile
       const cacheManifestPath = path.join(PUBLISH_DIR, cacheManifestFileName)


### PR DESCRIPTION
**Description of the PR**

The purpose of this plugin is to save this cache manifest to the publish directory. However, the plugin is running after the deploy currently so the file isn't saved.

This is a PR to change which stage of the build is used to run this plugin. The new stage (`onPostBuild` instead of `onEnd`) will be after the build but before the deploy which will allow the `cache-output.json` file to be saved to the publish directory as intended.
